### PR TITLE
Add delete typeorm service

### DIFF
--- a/.changeset/healthy-spiders-sleep.md
+++ b/.changeset/healthy-spiders-sleep.md
@@ -1,0 +1,5 @@
+---
+"@cuaklabs/porygon-typeorm": minor
+---
+
+Added `DeleteTypeOrmService`.

--- a/packages/porygon-typeorm/src/index.ts
+++ b/packages/porygon-typeorm/src/index.ts
@@ -1,3 +1,4 @@
+import { DeleteTypeOrmService } from './persistence/services/typeorm/DeleteTypeOrmService';
 import { InsertTypeOrmService } from './persistence/services/typeorm/InsertTypeOrmService';
 
-export { InsertTypeOrmService };
+export { DeleteTypeOrmService, InsertTypeOrmService };

--- a/packages/porygon-typeorm/src/persistence/converters/typeorm/QueryToFindQueryTypeOrmConverter.ts
+++ b/packages/porygon-typeorm/src/persistence/converters/typeorm/QueryToFindQueryTypeOrmConverter.ts
@@ -1,0 +1,18 @@
+import { ConverterAsync } from '@cuaklabs/porygon-common';
+import {
+  FindManyOptions,
+  ObjectLiteral,
+  QueryBuilder,
+  WhereExpressionBuilder,
+} from 'typeorm';
+
+export type QueryToFindQueryTypeOrmConverter<
+  TModelDb extends ObjectLiteral,
+  TQuery,
+> =
+  | ConverterAsync<TQuery, FindManyOptions<TModelDb>>
+  | ConverterAsync<
+      TQuery,
+      QueryBuilder<TModelDb> & WhereExpressionBuilder,
+      QueryBuilder<TModelDb> & WhereExpressionBuilder
+    >;

--- a/packages/porygon-typeorm/src/persistence/converters/typeorm/QueryWithQueryBuilderToFindQueryTypeOrmConverter.ts
+++ b/packages/porygon-typeorm/src/persistence/converters/typeorm/QueryWithQueryBuilderToFindQueryTypeOrmConverter.ts
@@ -1,0 +1,16 @@
+import { ConverterAsync } from '@cuaklabs/porygon-common';
+import {
+  FindManyOptions,
+  ObjectLiteral,
+  QueryBuilder,
+  WhereExpressionBuilder,
+} from 'typeorm';
+
+export type QueryWithQueryBuilderToFindQueryTypeOrmConverter<
+  TModelDb extends ObjectLiteral,
+  TQuery,
+> = ConverterAsync<
+  TQuery,
+  FindManyOptions<TModelDb> | (QueryBuilder<TModelDb> & WhereExpressionBuilder),
+  QueryBuilder<TModelDb> & WhereExpressionBuilder
+>;

--- a/packages/porygon-typeorm/src/persistence/services/typeorm/DeleteTypeOrmService.int.spec.ts
+++ b/packages/porygon-typeorm/src/persistence/services/typeorm/DeleteTypeOrmService.int.spec.ts
@@ -1,0 +1,267 @@
+import path from 'path';
+
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  Column,
+  ColumnType,
+  DataSource,
+  DataSourceOptions,
+  Entity,
+  FindManyOptions,
+  Not,
+  PrimaryColumn,
+  QueryRunner,
+  Repository,
+  Table,
+  TableColumn,
+} from 'typeorm';
+
+import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
+import { DeleteTypeOrmService } from './DeleteTypeOrmService';
+
+function getModelTestTable(fooColumnName: string, idColumnName: string): Table {
+  const modelTestTableName: string = 'model_test';
+
+  const modelTestTable: Table = new Table({
+    columns: [
+      {
+        isPrimary: false,
+        length: '128',
+        name: fooColumnName,
+        type: 'varchar',
+      },
+      {
+        isPrimary: true,
+        length: '36',
+        name: idColumnName,
+        type: 'varchar',
+      },
+    ],
+    name: modelTestTableName,
+  });
+
+  return modelTestTable;
+}
+
+async function setupModelTestTable(
+  queryRunner: QueryRunner,
+  modelTestTable: Table,
+): Promise<void> {
+  await tearDownModelTestTable(queryRunner, modelTestTable);
+
+  await queryRunner.createTable(modelTestTable);
+}
+
+async function tearDownModelTestTable(
+  queryRunner: QueryRunner,
+  modelTestTable: Table,
+): Promise<void> {
+  if (await queryRunner.hasTable(modelTestTable)) {
+    await queryRunner.dropTable(modelTestTable);
+  }
+}
+
+function decorateModelTest(
+  modelTestTable: Table,
+  fooColumnName: keyof ModelTest,
+  idColumnName: keyof ModelTest,
+): void {
+  const idColumn: TableColumn = modelTestTable.columns.find(
+    (tableColumn: TableColumn) => tableColumn.name === idColumnName,
+  ) as TableColumn;
+  const fooColumn: TableColumn = modelTestTable.columns.find(
+    (tableColumn: TableColumn) => tableColumn.name === fooColumnName,
+  ) as TableColumn;
+
+  PrimaryColumn({
+    length: idColumn.length,
+    name: idColumn.name,
+    type: idColumn.type as ColumnType,
+  })(ModelTest.prototype, idColumn.name);
+
+  Column({
+    length: fooColumn.length,
+    name: fooColumn.name,
+    type: fooColumn.type as ColumnType,
+  })(ModelTest.prototype, fooColumn.name);
+
+  Entity(modelTestTable.name)(ModelTest);
+}
+
+class ModelTest {
+  public id!: string;
+  public foo!: string;
+}
+
+interface QueryTest {
+  fooValue: string;
+}
+
+describe(DeleteTypeOrmService.name, () => {
+  let modelTestTable: Table;
+  let datasource: DataSource;
+  let queryRunner: QueryRunner;
+
+  let modelTestRepository: Repository<ModelTest>;
+  let queryToQueryTypeOrmConverter: QueryToFindQueryTypeOrmConverter<
+    ModelTest,
+    QueryTest
+  >;
+
+  let deleteTypeOrmAdapter: DeleteTypeOrmService<ModelTest, QueryTest>;
+
+  beforeAll(async () => {
+    const fooColumnName: keyof ModelTest = 'foo';
+    const idColumnName: keyof ModelTest = 'id';
+
+    modelTestTable = getModelTestTable(fooColumnName, idColumnName);
+
+    decorateModelTest(modelTestTable, fooColumnName, idColumnName);
+
+    const datasourceOptions: DataSourceOptions = {
+      database: path.resolve('tmp', 'typeorm', 'DeleteTypeOrmAdapter.sqlite'),
+      entities: [ModelTest],
+      logging: false,
+      type: 'sqlite',
+    };
+
+    datasource = new DataSource(datasourceOptions);
+
+    await datasource.initialize();
+
+    queryRunner = datasource.createQueryRunner();
+
+    await setupModelTestTable(queryRunner, modelTestTable);
+
+    modelTestRepository = datasource.getRepository(ModelTest);
+    queryToQueryTypeOrmConverter = {
+      convert: jest.fn(),
+    } as unknown as jest.Mocked<
+      QueryToFindQueryTypeOrmConverter<ModelTest, QueryTest>
+    >;
+
+    deleteTypeOrmAdapter = new DeleteTypeOrmService<ModelTest, QueryTest>(
+      modelTestRepository,
+      queryToQueryTypeOrmConverter,
+    );
+  });
+
+  describe('.delete', () => {
+    describe('having a model', () => {
+      let modelTest: ModelTest;
+
+      beforeAll(() => {
+        modelTest = new ModelTest();
+        modelTest.id = '836d2558-0f11-4c63-beb9-e78edba50428';
+        modelTest.foo = 'some foo value';
+      });
+
+      describe('when called, and model is on db and queryToFindQueryTypeOrmConverter.convert returns a typeorm find query matching a ModelTest', () => {
+        beforeAll(async () => {
+          await modelTestRepository.save(modelTest);
+
+          const queryTest: QueryTest = {
+            fooValue: 'blah',
+          };
+
+          const queryTypeOrmFixture: FindManyOptions<ModelTest> = {
+            where: {
+              id: modelTest.id,
+            },
+          };
+
+          (
+            queryToQueryTypeOrmConverter.convert as jest.Mock<
+              (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
+            >
+          ).mockResolvedValueOnce(queryTypeOrmFixture);
+
+          await deleteTypeOrmAdapter.delete(queryTest);
+        });
+
+        afterAll(async () => {
+          await modelTestRepository.delete({
+            id: modelTest.id,
+          });
+
+          jest.clearAllMocks();
+        });
+
+        describe('when called and modelTestRepository.findOne() with a typeorm find query matching the ModelTest', () => {
+          let result: unknown;
+
+          beforeAll(async () => {
+            const queryTypeOrmFixture: FindManyOptions<ModelTest> = {
+              where: {
+                id: modelTest.id,
+              },
+            };
+
+            result = await modelTestRepository.findOne(queryTypeOrmFixture);
+          });
+
+          it('should return null', () => {
+            expect(result).toBeNull();
+          });
+        });
+      });
+
+      describe('when called, and model is on db and queryToFindQueryTypeOrmConverter.convert returns a typeorm find query not matching a ModelTest', () => {
+        beforeAll(async () => {
+          await modelTestRepository.save(modelTest);
+
+          const queryTest: QueryTest = {
+            fooValue: 'blah',
+          };
+
+          const queryTypeOrmFixture: FindManyOptions<ModelTest> = {
+            where: {
+              id: Not(modelTest.id),
+            },
+          };
+
+          (
+            queryToQueryTypeOrmConverter.convert as jest.Mock<
+              (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
+            >
+          ).mockResolvedValueOnce(queryTypeOrmFixture);
+
+          await deleteTypeOrmAdapter.delete(queryTest);
+        });
+
+        afterAll(async () => {
+          await modelTestRepository.delete({
+            id: modelTest.id,
+          });
+
+          jest.clearAllMocks();
+        });
+
+        describe('when called modelTestRepository.findOne() with a typeorm find query matching the ModelTest', () => {
+          let result: unknown;
+
+          beforeAll(async () => {
+            const queryTypeOrmFixture: FindManyOptions<ModelTest> = {
+              where: {
+                id: modelTest.id,
+              },
+            };
+
+            result = await modelTestRepository.findOne(queryTypeOrmFixture);
+          });
+
+          it('should return a model test', () => {
+            expect(result).toStrictEqual(modelTest);
+          });
+        });
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await tearDownModelTestTable(queryRunner, modelTestTable);
+
+    await datasource.destroy();
+  });
+});

--- a/packages/porygon-typeorm/src/persistence/services/typeorm/DeleteTypeOrmService.spec.ts
+++ b/packages/porygon-typeorm/src/persistence/services/typeorm/DeleteTypeOrmService.spec.ts
@@ -1,0 +1,186 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  FindManyOptions,
+  FindOptionsWhere,
+  QueryBuilder,
+  Repository,
+  WhereExpressionBuilder,
+} from 'typeorm';
+
+jest.mock('../../utils/typeorm/findManyOptionsToFindOptionsWhere');
+
+import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
+import { findManyOptionsToFindOptionsWhere } from '../../utils/typeorm/findManyOptionsToFindOptionsWhere';
+import { DeleteTypeOrmService } from './DeleteTypeOrmService';
+
+interface ModelTest {
+  foo: unknown;
+}
+
+interface QueryTest {
+  fooValue: unknown;
+}
+
+describe(DeleteTypeOrmService.name, () => {
+  let queryBuilderMock: jest.Mocked<
+    QueryBuilder<ModelTest> & WhereExpressionBuilder
+  >;
+  let repositoryMock: jest.Mocked<Repository<ModelTest>>;
+  let queryToQueryTypeOrmConverterMock: jest.Mocked<
+    QueryToFindQueryTypeOrmConverter<ModelTest, QueryTest>
+  >;
+  let deleteTypeOrmAdapter: DeleteTypeOrmService<ModelTest, QueryTest>;
+
+  beforeAll(() => {
+    queryBuilderMock = Object.assign(
+      Object.create(QueryBuilder.prototype) as QueryBuilder<ModelTest>,
+      {
+        delete: jest.fn().mockReturnThis(),
+        execute: jest.fn(),
+      } as Partial<
+        jest.Mocked<QueryBuilder<ModelTest> & WhereExpressionBuilder>
+      > as jest.Mocked<QueryBuilder<ModelTest> & WhereExpressionBuilder>,
+    );
+
+    repositoryMock = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilderMock),
+      delete: jest.fn(),
+    } as Partial<jest.Mocked<Repository<ModelTest>>> as jest.Mocked<
+      Repository<ModelTest>
+    >;
+
+    queryToQueryTypeOrmConverterMock = {
+      convert: jest.fn(),
+    } as unknown as jest.Mocked<
+      QueryToFindQueryTypeOrmConverter<ModelTest, QueryTest>
+    >;
+
+    deleteTypeOrmAdapter = new DeleteTypeOrmService(
+      repositoryMock,
+      queryToQueryTypeOrmConverterMock,
+    );
+  });
+
+  describe('.delete', () => {
+    describe('when called and queryToQueryTypeOrmConverter returns FindManyOptions<ModelTest>', () => {
+      let queryFixture: QueryTest;
+      let queryTypeOrmFixture: FindManyOptions<ModelTest>;
+      let findOptionsWhereFixture: FindOptionsWhere<ModelTest>;
+
+      beforeAll(async () => {
+        queryFixture = {
+          fooValue: 'foo-value',
+        };
+
+        findOptionsWhereFixture = {};
+
+        queryTypeOrmFixture = {
+          where: findOptionsWhereFixture,
+        };
+
+        (
+          queryToQueryTypeOrmConverterMock.convert as jest.Mock<
+            (query: QueryTest) => Promise<FindManyOptions<ModelTest>>
+          >
+        ).mockResolvedValueOnce(queryTypeOrmFixture);
+
+        (
+          findManyOptionsToFindOptionsWhere as jest.Mock<
+            typeof findManyOptionsToFindOptionsWhere
+          >
+        ).mockReturnValueOnce(findOptionsWhereFixture);
+
+        await deleteTypeOrmAdapter.delete(queryFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call repository.createQueryBuilder()', () => {
+        expect(repositoryMock.createQueryBuilder).toHaveBeenCalledTimes(1);
+        expect(repositoryMock.createQueryBuilder).toHaveBeenCalledWith();
+      });
+
+      it('should call queryBuilder.delete()', () => {
+        expect(queryBuilderMock.delete).toHaveBeenCalledTimes(1);
+        expect(queryBuilderMock.delete).toHaveBeenCalledWith();
+      });
+
+      it('should call queryToQueryTypeOrmConverter.convert()', () => {
+        expect(queryToQueryTypeOrmConverterMock.convert).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(queryToQueryTypeOrmConverterMock.convert).toHaveBeenCalledWith(
+          queryFixture,
+          queryBuilderMock,
+        );
+      });
+
+      it('should call findManyOptionsToFindOptionsWhere()', () => {
+        expect(findManyOptionsToFindOptionsWhere).toHaveBeenCalledTimes(1);
+        expect(findManyOptionsToFindOptionsWhere).toHaveBeenCalledWith(
+          queryTypeOrmFixture,
+        );
+      });
+
+      it('should call repositoryMock.delete()', () => {
+        expect(repositoryMock.delete).toHaveBeenCalledTimes(1);
+        expect(repositoryMock.delete).toHaveBeenCalledWith(
+          findOptionsWhereFixture,
+        );
+      });
+    });
+
+    describe('when called and queryToQueryTypeOrmConverter returns QueryBuilder<ModelTest>', () => {
+      let queryFixture: QueryTest;
+
+      beforeAll(async () => {
+        queryFixture = {
+          fooValue: 'foo-value',
+        };
+
+        (
+          queryToQueryTypeOrmConverterMock.convert as jest.Mock<
+            (
+              query: QueryTest,
+              context: QueryBuilder<ModelTest> & WhereExpressionBuilder,
+            ) => Promise<QueryBuilder<ModelTest> & WhereExpressionBuilder>
+          >
+        ).mockResolvedValueOnce(queryBuilderMock);
+
+        await deleteTypeOrmAdapter.delete(queryFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call repository.createQueryBuilder()', () => {
+        expect(repositoryMock.createQueryBuilder).toHaveBeenCalledTimes(1);
+        expect(repositoryMock.createQueryBuilder).toHaveBeenCalledWith();
+      });
+
+      it('should call queryBuilder.delete()', () => {
+        expect(queryBuilderMock.delete).toHaveBeenCalledTimes(1);
+        expect(queryBuilderMock.delete).toHaveBeenCalledWith();
+      });
+
+      it('should call queryToQueryTypeOrmConverter.convert()', () => {
+        expect(queryToQueryTypeOrmConverterMock.convert).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(queryToQueryTypeOrmConverterMock.convert).toHaveBeenCalledWith(
+          queryFixture,
+          queryBuilderMock,
+        );
+      });
+
+      it('should call queryBuilder.execute()', () => {
+        expect(queryBuilderMock.execute).toHaveBeenCalledTimes(1);
+        expect(queryBuilderMock.execute).toHaveBeenCalledWith();
+      });
+    });
+  });
+});

--- a/packages/porygon-typeorm/src/persistence/services/typeorm/DeleteTypeOrmService.ts
+++ b/packages/porygon-typeorm/src/persistence/services/typeorm/DeleteTypeOrmService.ts
@@ -1,0 +1,58 @@
+import {
+  DeleteQueryBuilder,
+  FindManyOptions,
+  FindOptionsWhere,
+  ObjectLiteral,
+  QueryBuilder,
+  Repository,
+} from 'typeorm';
+
+import { QueryToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryToFindQueryTypeOrmConverter';
+import { QueryWithQueryBuilderToFindQueryTypeOrmConverter } from '../../converters/typeorm/QueryWithQueryBuilderToFindQueryTypeOrmConverter';
+import { findManyOptionsToFindOptionsWhere } from '../../utils/typeorm/findManyOptionsToFindOptionsWhere';
+
+export class DeleteTypeOrmService<TModelDb extends ObjectLiteral, TQuery> {
+  readonly #repository: Repository<TModelDb>;
+  readonly #queryToQueryTypeOrmConverter: QueryToFindQueryTypeOrmConverter<
+    TModelDb,
+    TQuery
+  >;
+
+  constructor(
+    repository: Repository<TModelDb>,
+    queryToQueryTypeOrmConverter: QueryToFindQueryTypeOrmConverter<
+      TModelDb,
+      TQuery
+    >,
+  ) {
+    this.#repository = repository;
+    this.#queryToQueryTypeOrmConverter = queryToQueryTypeOrmConverter;
+  }
+
+  public async delete(query: TQuery): Promise<void> {
+    const deleteQueryBuilder: DeleteQueryBuilder<TModelDb> = this.#repository
+      .createQueryBuilder()
+      .delete();
+
+    const findQueryTypeOrmOrQueryBuilder:
+      | FindManyOptions<TModelDb>
+      | QueryBuilder<TModelDb> = await (
+      this
+        .#queryToQueryTypeOrmConverter as QueryWithQueryBuilderToFindQueryTypeOrmConverter<
+        TModelDb,
+        TQuery
+      >
+    ).convert(query, deleteQueryBuilder);
+
+    if (findQueryTypeOrmOrQueryBuilder instanceof QueryBuilder) {
+      await (
+        findQueryTypeOrmOrQueryBuilder as DeleteQueryBuilder<TModelDb>
+      ).execute();
+    } else {
+      const findQueryTypeOrmWhere: FindOptionsWhere<TModelDb> =
+        findManyOptionsToFindOptionsWhere(findQueryTypeOrmOrQueryBuilder);
+
+      await this.#repository.delete(findQueryTypeOrmWhere);
+    }
+  }
+}

--- a/packages/porygon-typeorm/src/persistence/utils/typeorm/findManyOptionsToFindOptionsWhere.spec.ts
+++ b/packages/porygon-typeorm/src/persistence/utils/typeorm/findManyOptionsToFindOptionsWhere.spec.ts
@@ -1,0 +1,117 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { FindManyOptions, FindOptionsWhere } from 'typeorm';
+
+import { findManyOptionsToFindOptionsWhere } from './findManyOptionsToFindOptionsWhere';
+
+interface ModelTest {
+  foo: string;
+}
+
+describe(findManyOptionsToFindOptionsWhere.name, () => {
+  describe('having a FindManyOptions with no where property', () => {
+    let findManyOptionsFixture: FindManyOptions<ModelTest>;
+
+    beforeAll(() => {
+      findManyOptionsFixture = {};
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findManyOptionsToFindOptionsWhere(findManyOptionsFixture);
+      });
+
+      it('should return default FindOptionsWhere', () => {
+        expect(result).toStrictEqual({});
+      });
+    });
+  });
+
+  describe('having a FindManyOptions with where property with FindOptionsWhere', () => {
+    let findOptionsWhereFixture: FindOptionsWhere<ModelTest>;
+    let findManyOptionsFixture: FindManyOptions<ModelTest>;
+
+    beforeAll(() => {
+      findOptionsWhereFixture = {
+        foo: 'foo value',
+      };
+      findManyOptionsFixture = {
+        where: findOptionsWhereFixture,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findManyOptionsToFindOptionsWhere(findManyOptionsFixture);
+      });
+
+      it('should return FindOptionsWhere', () => {
+        expect(result).toStrictEqual(findOptionsWhereFixture);
+      });
+    });
+  });
+
+  describe('having a FindManyOptions with where property with an array with one element', () => {
+    let findOptionsWhereFixture: FindOptionsWhere<ModelTest>;
+    let findManyOptionsFixture: FindManyOptions<ModelTest>;
+
+    beforeAll(() => {
+      findOptionsWhereFixture = {
+        foo: 'foo value',
+      };
+      findManyOptionsFixture = {
+        where: [findOptionsWhereFixture],
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findManyOptionsToFindOptionsWhere(findManyOptionsFixture);
+      });
+
+      it('should return FindOptionsWhere', () => {
+        expect(result).toStrictEqual(findOptionsWhereFixture);
+      });
+    });
+  });
+
+  describe('having a FindManyOptions with where property with an array with not one element', () => {
+    let findManyOptionsFixture: FindManyOptions<ModelTest>;
+
+    beforeAll(() => {
+      findManyOptionsFixture = {
+        where: [],
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          findManyOptionsToFindOptionsWhere(findManyOptionsFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<Error> = {
+          message:
+            'Unexpected multiple FindOptionsWhere inside FindManyOptions: operation not allowed',
+        };
+
+        expect(result).toBeInstanceOf(Error);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+});

--- a/packages/porygon-typeorm/src/persistence/utils/typeorm/findManyOptionsToFindOptionsWhere.ts
+++ b/packages/porygon-typeorm/src/persistence/utils/typeorm/findManyOptionsToFindOptionsWhere.ts
@@ -1,0 +1,40 @@
+import { FindManyOptions, FindOptionsWhere } from 'typeorm';
+
+export function findManyOptionsToFindOptionsWhere<TModelDb>(
+  findManyOptions: FindManyOptions<TModelDb>,
+): FindOptionsWhere<TModelDb> {
+  const findManyOptionsWhere:
+    | FindOptionsWhere<TModelDb>
+    | FindOptionsWhere<TModelDb>[]
+    | undefined = findManyOptions.where;
+
+  let findOptionsWhere: FindOptionsWhere<TModelDb>;
+
+  if (Array.isArray(findManyOptionsWhere)) {
+    findOptionsWhere =
+      findOptionsWhereArrayToFindOptionsWhere(findManyOptionsWhere);
+  } else {
+    findOptionsWhere = findManyOptionsWhere ?? getDefaultFindOptionsWhere();
+  }
+
+  return findOptionsWhere;
+}
+
+function findOptionsWhereArrayToFindOptionsWhere<TModelDb>(
+  findOptionsWhereArray: FindOptionsWhere<TModelDb>[],
+): FindOptionsWhere<TModelDb> {
+  if (findOptionsWhereArray.length === 1) {
+    const [findOptionsWhere]: [FindOptionsWhere<TModelDb>] =
+      findOptionsWhereArray as [FindOptionsWhere<TModelDb>];
+
+    return findOptionsWhere;
+  } else {
+    throw new Error(
+      'Unexpected multiple FindOptionsWhere inside FindManyOptions: operation not allowed',
+    );
+  }
+}
+
+function getDefaultFindOptionsWhere<TModelDb>(): FindOptionsWhere<TModelDb> {
+  return {};
+}


### PR DESCRIPTION
### Added
- Added `DeleteTypeOrmService`.
- Added `QueryToFindQueryTypeOrmConverter` types.
- Added `findManyOptionsToFindOptionsWhere`.