### PR TITLE
chore(renovate): update config to ignore eslint-plugin-import

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     "pnpm": "7"
   },
   "extends": ["config:base", ":disableRateLimiting"],
+  "ignoreDeps": ["eslint-plugin-import"],
   "rebaseWhen": "conflicted",
   "semanticCommits": "enabled",
   "schedule": [


### PR DESCRIPTION
### Changed
- Updated renovate bot config to ignore `eslint-plugin-import` updates.